### PR TITLE
use fsnotify.v0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ go:
 install:
   - go get code.google.com/p/go.tools/cmd/cover
   - go get github.com/robertkrimen/otto
-  - go get code.google.com/p/go.exp/fsnotify
+  - go get gopkg.in/fsnotify.v0
 script:
   - go test -cover github.com/robfig/soy/...

--- a/bundle.go
+++ b/bundle.go
@@ -9,12 +9,12 @@ import (
 	"strings"
 	"time"
 
-	"code.google.com/p/go.exp/fsnotify"
 	"github.com/robfig/soy/data"
 	"github.com/robfig/soy/parse"
 	"github.com/robfig/soy/parsepasses"
 	"github.com/robfig/soy/soyhtml"
 	"github.com/robfig/soy/template"
+	"gopkg.in/fsnotify.v0"
 )
 
 // Logger is used to print notifications and compile errors when using the


### PR DESCRIPTION
fsnotify is currently being maintained at: https://github.com/go-fsnotify/fsnotify

fsnotify.v0 matches the API you are using but some bugs have been fixed. There
is also a newer v1 API if you wish to upgrade.

(So I know when this is merged, ref: https://github.com/go-fsnotify/fsnotify/issues/35)
