### PR TITLE
Return a pointer from NewMessage to store it easier.

### DIFF
--- a/soyhtml/exec_test.go
+++ b/soyhtml/exec_test.go
@@ -841,7 +841,7 @@ func newFakeBundle(msg, tran string, pl po.PluralSelector) *fakeBundle {
 	var msgnode = sf.Body[0].(*ast.MsgNode)
 	soymsg.SetPlaceholdersAndID(msgnode)
 	var m = soymsg.NewMessage(msgnode.ID, tran)
-	return &fakeBundle{map[uint64]*soymsg.Message{msgnode.ID: &m}, pl}
+	return &fakeBundle{map[uint64]*soymsg.Message{msgnode.ID: m}, pl}
 }
 
 func newFakePluralBundle(pluralVar, msg1, msg2 string, pl po.PluralSelector, msgstr []string) *fakeBundle {

--- a/soymsg/soymsg.go
+++ b/soymsg/soymsg.go
@@ -81,8 +81,8 @@ const (
 
 // NewMessage returns a new message, given its ID and placeholder string.
 // TODO: plural parts are not parsed from the placeholder string.
-func NewMessage(id uint64, phstr string) Message {
-	return Message{id, Parts(phstr)}
+func NewMessage(id uint64, phstr string) *Message {
+	return &Message{id, Parts(phstr)}
 }
 
 // PlaceholderString returns a string representation of the message containing


### PR DESCRIPTION
This changes allows to store the generated messages in something like ```map[uint64]*soymsg.Message``` without the hassle of a temporary variable. For example we can now do this:

```go
cache := map[uint64]*soymsg.Message{}
cache[message.ID] = soymsg.NewMessage(message.ID, message.Value)
```

instead of this:

```go
cache := map[uint64]*soymsg.Message{}
m := soymsg.NewMessage(message.ID, message.Value)
cache[message.ID] = &m
```

