### PR TITLE
Add deprecated-contextual as a valid autoescape value.

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -606,6 +606,8 @@ func (t *tree) parseAutoescape(attrs map[string]string) ast.AutoescapeType {
 		return ast.AutoescapeUnspecified
 	case "contextual":
 		return ast.AutoescapeContextual
+	case "deprecated-contextual":
+		return ast.AutoescapeContextual
 	case "true":
 		return ast.AutoescapeOn
 	case "false":


### PR DESCRIPTION
```contextual``` has been renamed to ```deprecated-contextual``` in the official implementation [1]. This change allows soy to support both the old syntax and the new one in the meanwhile.

[1] https://github.com/google/closure-templates/blob/2845e9a3836e7bf8d7166df2b7c79a5fa59fad60/java/src/com/google/template/soy/soytree/AutoescapeMode.java#L39