### PR TITLE
Fix soyjs 'foreach' parsing when the List argument isn't a DataRefNod…

### DIFF
--- a/soyjs/exec.go
+++ b/soyjs/exec.go
@@ -415,10 +415,10 @@ func (s *state) visitIf(node *ast.IfNode) {
 }
 
 func (s *state) visitFor(node *ast.ForNode) {
-	if _, isForeach := node.List.(*ast.DataRefNode); isForeach {
-		s.visitForeach(node)
-	} else {
+	if rangeNode, ok := node.List.(*ast.FunctionNode); ok && rangeNode.Name == "range" {
 		s.visitForRange(node)
+	} else {
+		s.visitForeach(node)
 	}
 }
 

--- a/soyjs/exec_test.go
+++ b/soyjs/exec_test.go
@@ -385,6 +385,18 @@ func TestSpecialChars(t *testing.T) {
 	})
 }
 
+func TestForeachElvis(t *testing.T) {
+	runExecTests(t, []execTest{
+		exprtest("foreachelvislet", `{template .foo}
+			{let $list: null ?: [] /}
+			{foreach $l in $list}{/foreach}
+			{/template}`, ""),
+		exprtest("foreachelvisinline", `{template .foo}
+			{foreach $l in null ?: []}{/foreach}
+			{/template}`, ""),
+	})
+}
+
 func TestLiteral(t *testing.T) {
 	runExecTests(t, []execTest{
 		exprtest("literal",


### PR DESCRIPTION
…e but is otherwise valid (ElvisNode, for example)

I believe this behavior is correct (tested against a large sample of templates).