### PR TITLE
Fixing a leak in the lexer.

### DIFF
--- a/parse/lexer.go
+++ b/parse/lexer.go
@@ -320,6 +320,12 @@ func (l *lexer) nextItem() item {
 	return <-l.items
 }
 
+// drain drains the output so the lexing goroutine will exit.
+func (l *lexer) drain() {
+	for _ = range l.items {
+	}
+}
+
 // lex creates a new scanner for the input string.
 func lex(name, input string) *lexer {
 	l := &lexer{

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -1185,6 +1185,7 @@ func (t *tree) recover(errp *error) {
 	if _, ok := e.(runtime.Error); ok {
 		panic(e)
 	}
+	t.lex.drain()
 	t.lex = nil
 	if str, ok := e.(string); ok {
 		*errp = errors.New(str)


### PR DESCRIPTION
If the parse aborts, the lexer goroutine would be left offering a token to a channel which would never be read.
The fix is to simply ensure the parser drains the lexer in this case.