### PR TITLE
data.New: nil slice => nil List (not Null)

### DIFF
--- a/data/convert.go
+++ b/data/convert.go
@@ -54,7 +54,7 @@ func NewWith(convert StructOptions, value interface{}) Value {
 		return String(v.String())
 	case reflect.Slice:
 		if v.IsNil() {
-			return Null{}
+			return List(nil)
 		}
 		slice := []Value{}
 		for i := 0; i < v.Len(); i++ {

--- a/data/convert_test.go
+++ b/data/convert_test.go
@@ -11,7 +11,6 @@ type AInt struct{ A int }
 var jan1, _ = time.Parse(time.RFC3339, "2014-01-01T00:00:00Z")
 
 func TestNew(t *testing.T) {
-	var nilSlice []bool
 	tests := []struct{ input, expected interface{} }{
 		// basic types
 		{nil, Null{}},
@@ -21,7 +20,7 @@ func TestNew(t *testing.T) {
 		{uint32(0), Int(0)},
 		{float32(0), Float(0)},
 		{"", String("")},
-		{nilSlice, Null{}},
+		{[]bool(nil), List(nil)},
 		{[]bool{}, List{}},
 		{[]string{"a"}, List{String("a")}},
 		{[]interface{}{"a"}, List{String("a")}},


### PR DESCRIPTION
Sorry, this was overlooked in my last PR.  This fixes things like `length($list) > 0` where `length` does a type assertion to `data.List`.