### PR TITLE
Add commas separating args in PrintDirectiveNode

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -198,12 +198,13 @@ func (n *PrintDirectiveNode) String() string {
 		return "|" + n.Name
 	}
 	var expr = "|" + n.Name + ":"
-	var first = false
+	var first = true
 	for _, arg := range n.Args {
-		if first {
+		if !first {
 			expr += ","
 		}
 		expr += arg.String()
+		first = false
 	}
 	return expr
 }


### PR DESCRIPTION
When converting a PrintDirectiveNode to a string, commas were not being added between the arguments, leading to invalid templates.