### PR TITLE
Fixed String() bugs for binary operators

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -828,7 +828,7 @@ type BinaryOpNode struct {
 }
 
 func (n *BinaryOpNode) String() string {
-	return n.Arg1.String() + n.Name + n.Arg2.String()
+	return n.Arg1.String() + " " + n.Name + " " + n.Arg2.String()
 }
 
 func (n *BinaryOpNode) Children() []Node {

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -1029,7 +1029,7 @@ func newBinaryOpNode(t item, n1, n2 ast.Node) ast.Node {
 	case itemSub:
 		return &ast.SubNode{op(bin, "-")}
 	case itemEq:
-		return &ast.EqNode{op(bin, "=")}
+		return &ast.EqNode{op(bin, "==")}
 	case itemNotEq:
 		return &ast.NotEqNode{op(bin, "!=")}
 	case itemGt:
@@ -1041,9 +1041,9 @@ func newBinaryOpNode(t item, n1, n2 ast.Node) ast.Node {
 	case itemLte:
 		return &ast.LteNode{op(bin, "<=")}
 	case itemOr:
-		return &ast.OrNode{op(bin, "or")}
+		return &ast.OrNode{op(bin, " or ")}
 	case itemAnd:
-		return &ast.AndNode{op(bin, "and")}
+		return &ast.AndNode{op(bin, " and ")}
 	case itemElvis:
 		return &ast.ElvisNode{op(bin, "?:")}
 	}

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -1041,9 +1041,9 @@ func newBinaryOpNode(t item, n1, n2 ast.Node) ast.Node {
 	case itemLte:
 		return &ast.LteNode{op(bin, "<=")}
 	case itemOr:
-		return &ast.OrNode{op(bin, " or ")}
+		return &ast.OrNode{op(bin, "or")}
 	case itemAnd:
-		return &ast.AndNode{op(bin, " and ")}
+		return &ast.AndNode{op(bin, "and")}
 	case itemElvis:
 		return &ast.ElvisNode{op(bin, "?:")}
 	}


### PR DESCRIPTION
EqNode should print the equals comparator and "and"/"or" need spaces before and after them when printed so that words don't run together.