### PR TITLE
Add ObligatoryPrintDirectives

### DIFF
--- a/soyhtml/directives.go
+++ b/soyhtml/directives.go
@@ -35,6 +35,11 @@ var PrintDirectives = map[string]PrintDirective{
 	"json":              {directiveJson, []int{0}, true},
 }
 
+// ObligatoryPrintDirectives are always called
+// These directives can't take arguments
+// Callers may add their own print directives to this list.
+var ObligatoryPrintDirectiveNames = []string{}
+
 func directiveInsertWordBreaks(value data.Value, args []data.Value) data.Value {
 	var (
 		input    = template.HTMLEscapeString(value.String())

--- a/soyhtml/exec.go
+++ b/soyhtml/exec.go
@@ -299,6 +299,14 @@ func (s *state) evalPrint(node *ast.PrintNode) {
 	}
 	var escapeHtml = s.autoescape != ast.AutoescapeOff
 	var result = s.val
+
+	for _, directiveName := range ObligatoryPrintDirectiveNames {
+		node.Directives = append(node.Directives, &ast.PrintDirectiveNode{
+			Pos:  node.Position(),
+			Name: directiveName,
+		})
+	}
+
 	for _, directiveNode := range node.Directives {
 		var directive, ok = PrintDirectives[directiveNode.Name]
 		if !ok {

--- a/soyhtml/exec_test.go
+++ b/soyhtml/exec_test.go
@@ -414,6 +414,14 @@ func TestPrintDirectives(t *testing.T) {
 	})
 }
 
+func TestObligatoryDirectives(t *testing.T) {
+	ObligatoryPrintDirectiveNames = []string{"noAutoescape"}
+	runExecTests(t, []execTest{
+		exprtest("obligatory noAutoescape", "{'<a>'}", "<a>"),
+	})
+	ObligatoryPrintDirectiveNames = []string{}
+}
+
 func TestGlobals(t *testing.T) {
 	globals["app.global_str"] = data.New("abc")
 	globals["GLOBAL_INT"] = data.New(5)


### PR DESCRIPTION
We sometimes print things that unexpectedly turn out to be null. This change would allow us to apply a default print directive that makes null render as an empty string instead of the text "null". 