### PR TITLE
Elvis fix

### DIFF
--- a/soyjs/exec.go
+++ b/soyjs/exec.go
@@ -201,9 +201,9 @@ func (s *state) walk(node ast.Node) {
 		s.op("||", node)
 	case *ast.ElvisNode:
 		// ?: is specified to check for null.
-		s.js("(", node.Arg1, " != null ? ", node.Arg1, " : ", node.Arg2, ")")
+		s.js("((", node.Arg1, ") != null ? ", node.Arg1, " : ", node.Arg2, ")")
 	case *ast.TernNode:
-		s.js("(", node.Arg1, "?", node.Arg2, ":", node.Arg3, ")")
+		s.js("((", node.Arg1, ") ?", node.Arg2, ":", node.Arg3, ")")
 
 	default:
 		s.errorf("unknown node (%T): %v", node, node)

--- a/soyjs/exec_test.go
+++ b/soyjs/exec_test.go
@@ -341,6 +341,18 @@ func TestDataRefs(t *testing.T) {
 		exprtestwdata("exprkeynullsafe on null map", "{$foo?['bar']}", "null", d{"foo": nil}),
 		exprtestwdata("exprkeyarith", "{$foo['b'+('a'+'r')]}", "result", d{"foo": d{"bar": "result"}}),
 
+		// nullsafe + elvis
+		exprtestwdata("elvis and nullsafe key", "{$foo?.bar ?: 'hello'}", "hello", d{}),
+		exprtestwdata("elvis and nullsafe key success", "{$foo?.bar ?: 'hello'}", "hi", d{"foo": d{"bar": "hi"}}),
+		exprtestwdata("elvis and nullsafe key half success", "{$foo?.bar ?: 'hello'}", "hello", d{"foo": d{}}),
+		exprtestwdata("elvis and nullsafe index ", "{$foo?[0] ?: 'hello'}", "hello", d{}),
+		exprtestwdata("elvis and nullsafe index success", "{$foo?[0] ?: 'hello'}", "a", d{"foo": []interface{}{"a", "b", "c", "d"}}),
+		exprtestwdata("elvis and nullsafe index half success", "{$foo?[0] ?: 'hello'}", "hello", d{"foo": []interface{}{}}),
+		exprtestwdata("elvis and nullsafe expr", "{$foo?['bar'] ?: 'hello'}", "hello", d{}),
+		exprtestwdata("elvis and nullsafe expr success", "{$foo?['bar'] ?: 'hello'}", "hi", d{"foo": d{"bar": "hi"}}),
+		exprtestwdata("elvis and nullsafe expr half success", "{$foo?['bar'] ?: 'hello'}", "hello", d{"foo": d{}}),
+		exprtestwdata("elvis and nullsafe chain", "{$foo?.bar?.baz ?: 'hello'}", "hello", d{"foo": d{"bar": d{}}}),
+
 		// DIFFERENCE: More tests on nullsafe navigation.
 		exprtestwdata("nullsafe battle royale",
 			"{$foo[2].bar?.baz?['bar']?[3].boo[3]}", "null", d{


### PR DESCRIPTION
For a statement like ```$foo?.bar ?: 'hello'``` we would get JS that looks like 

```
(foo == null) ?
  null : 
  foo.bar != null ?
    (foo == null) ?
      null :
      foo.bar
  : 'hello'
```

Instead, we want something like the following, where the first ternary statement is grouped and its value is what is null checked in the ``` != null ``` statement. 

```
((foo == null) ?
  null : 
  foo.bar) != null ?
    (foo == null) ?
      null :
      foo.bar
  : 'hello'
```