### PR TITLE
Change in quote parsing to render a backslash in soy string

### DIFF
--- a/parse/quote.go
+++ b/parse/quote.go
@@ -82,7 +82,7 @@ func unquoteString(s string) (string, error) {
 			}
 		}
 
-		escaping = r == '\\'
+		escaping = ((r == '\\') && !escaping)
 		if !escaping {
 			result = append(result, r)
 		}

--- a/parse/quote_test.go
+++ b/parse/quote_test.go
@@ -10,6 +10,8 @@ func TestQuote(t *testing.T) {
 		{"\u2222", "'\u2222'"}, // (doesn't turn it back into escape sequence)
 		{"Aa`! \n \r \t \\ ' \"", "'Aa`! \\n \\r \\t \\\\ \\' \"'"},
 		{"\u2222 \uEEEE \u9EC4 \u607A", "'\u2222 \uEEEE \u9EC4 \u607A'"},
+		{"\\.", `'\\.'`},
+		{"\\\n", `'\\\n'`},
 	}
 	for _, test := range tests {
 		if quoteString(test.input) != test.output {
@@ -25,6 +27,8 @@ func TestUnquote(t *testing.T) {
 		{`'\n'`, "\n"},
 		{`'\u2222'`, "\u2222"},
 		{`'\\'`, "\\"},
+		{`'\\.'`, "\\."},
+		{`'\\\n'`, "\\\n"},
 	}
 	for _, test := range tests {
 		actual, err := unquoteString(test.input)

--- a/parse/quote_test.go
+++ b/parse/quote_test.go
@@ -24,6 +24,7 @@ func TestUnquote(t *testing.T) {
 		{`'a'`, "a"},
 		{`'\n'`, "\n"},
 		{`'\u2222'`, "\u2222"},
+		{`'\\'`, "\\"},
 	}
 	for _, test := range tests {
 		actual, err := unquoteString(test.input)


### PR DESCRIPTION
Idea: allow an actual backslash in soy strings (can achieve this with in soy by using writing string '\\\\')
Purpose: allowing an actual backslash will let us escape special characters in regex expressions
Changes: previously \\\\n -> '\\n' now \\\\n -> '\\' + 'n'. The backslash always escapes the character directly after it and escapes are done in pairs