### PR TITLE
PC-24819: make soyjs output ES6 compatible javascript (imports/exports)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
 install:
   - go get golang.org/x/tools/cmd/cover || true
   - go get code.google.com/p/go.tools/cmd/cover || true
+  - go get github.com/andreyvit/diff
   - go get github.com/robertkrimen/otto
   - go get github.com/howeyc/fsnotify
   - go get github.com/robfig/gettext/po

--- a/soyjs/exec.go
+++ b/soyjs/exec.go
@@ -29,63 +29,85 @@ type state struct {
 	funcsInFile  map[string]bool
 }
 
+// ES5Formatter implements the JSFormatter interface
+// and creates Javascript files following the ES5
+// Javascript format (without imports)
 type ES5Formatter struct{}
+
+// ES6Formatter implements the JSFormatter interface
+// and creates Javascript files following the ES6
+// Javascript format (with imports)
 type ES6Formatter struct{}
 
 var _ JSFormatter = (*ES6Formatter)(nil)
 var _ JSFormatter = (*ES5Formatter)(nil)
 
+// Template returns two values, the name of the template to save
+// in the defined functions map, and how the function should be defined.
+// For ES5, the function is not exported, but defined globally
 func (f ES5Formatter) Template(name string) (string, string) {
 	return name, name + " = function"
 }
 
+// Call returns two values, the name of the template to save
+// in the called functions map, and a string that is written
+// into the imports - for ES5, there are no imports
 func (f ES5Formatter) Call(name string) (string, string) {
 	return name, ""
 }
 
+// Directive takes in a PrintDirective and returns a string
+// that is written into the imports - for ES5, there
+// are no imports
 func (f ES5Formatter) Directive(dir PrintDirective) string {
 	return ""
 }
 
+// Function takes in a Func and returns a string
+// that is written into the imports - for ES5, there
+// are no imports
 func (f ES5Formatter) Function(fn Func) string {
 	return ""
 }
 
+// es6Identifier creates an ES6 compatible function name
+// without periods. It replaces all periods, which usually
+// denominate namespaces in soy, with a double underscore.
+// For example, from the file
+// {namespace say}
+// {template .hello_world}
+// Hello World
+// {/template}
+// when es6Identifier is called on say.hello_world,
+// it will return say__hello_world
 func es6Identifier(s string) string {
 	return strings.Replace(s, ".", "__", -1)
 }
 
+// Template returns two values, the name of the template to save
+// in the defined functions map, and how the function should be defined.
+// For ES5, the function is not defined globally, but exported
 func (f ES6Formatter) Template(name string) (string, string) {
 	return es6Identifier(name), "export function " + es6Identifier(name)
 }
 
+// Call returns two values, the name of the template to save
+// in the called functions map, and a string that is written
+// into the imports
 func (f ES6Formatter) Call(name string) (string, string) {
 	return es6Identifier(name), "import { " + es6Identifier(name) + " } from '" + name + ".js';"
 }
 
+// Directive takes in a PrintDirective and returns a string
+// that is written into the imports
 func (f ES6Formatter) Directive(dir PrintDirective) string {
 	return "import { " + es6Identifier(dir.Name) + " } from '" + dir.Name + ".js';"
 }
 
+// Function takes in a Func and returns a string
+// that is written into the imports
 func (f ES6Formatter) Function(fn Func) string {
 	return "import { " + es6Identifier(fn.Name) + " } from '" + fn.Name + ".js';"
-}
-
-// removes duplicates from a slice
-func removeDuplicates(elements []string) []string {
-	encountered := map[string]bool{}
-
-	// Create a map of all unique elements.
-	for v := range elements {
-		encountered[elements[v]] = true
-	}
-
-	// Place all keys from the map into a slice.
-	result := []string{}
-	for key := range encountered {
-		result = append(result, key)
-	}
-	return result
 }
 
 func difference(a map[string]string, b map[string]bool) []string {
@@ -123,10 +145,10 @@ func Write(out io.Writer, node ast.Node, options Options) (err error) {
 
 	if len(s.funcsCalled) > 0 {
 		for _, f := range difference(s.funcsCalled, s.funcsInFile) {
-			importsBuf.Write([]byte(s.funcsCalled[f]))
-			importsBuf.Write([]byte("\n"))
+			importsBuf.WriteString(s.funcsCalled[f])
+			importsBuf.WriteRune('\n')
 		}
-		importsBuf.Write([]byte("\n"))
+		importsBuf.WriteRune('\n')
 	}
 
 	out.Write(importsBuf.Bytes())

--- a/soyjs/exec.go
+++ b/soyjs/exec.go
@@ -25,15 +25,113 @@ type state struct {
 	autoescape   ast.AutoescapeType
 	lastNode     ast.Node
 	options      Options
+	funcsCalled  map[string]string
+	funcsInFile  map[string]bool
+}
+
+type ES5Formatter struct{}
+type ES6Formatter struct{}
+
+var _ JSFormatter = (*ES6Formatter)(nil)
+var _ JSFormatter = (*ES5Formatter)(nil)
+
+func (f ES5Formatter) Template(name string) (string, string) {
+	return name, name + " = function"
+}
+
+func (f ES5Formatter) Call(name string) (string, string) {
+	return name, ""
+}
+
+func (f ES5Formatter) Directive(dir PrintDirective) string {
+	return ""
+}
+
+func (f ES5Formatter) Function(fn Func) string {
+	return ""
+}
+
+func es6Identifier(s string) string {
+	return strings.Replace(s, ".", "__", -1)
+}
+
+func (f ES6Formatter) Template(name string) (string, string) {
+	return es6Identifier(name), "export function " + es6Identifier(name)
+}
+
+func (f ES6Formatter) Call(name string) (string, string) {
+	return es6Identifier(name), "import { " + es6Identifier(name) + " } from '" + name + ".js';"
+}
+
+func (f ES6Formatter) Directive(dir PrintDirective) string {
+	return "import { " + es6Identifier(dir.Name) + " } from '" + dir.Name + ".js';"
+}
+
+func (f ES6Formatter) Function(fn Func) string {
+	return "import { " + es6Identifier(fn.Name) + " } from '" + fn.Name + ".js';"
+}
+
+// removes duplicates from a slice
+func removeDuplicates(elements []string) []string {
+	encountered := map[string]bool{}
+
+	// Create a map of all unique elements.
+	for v := range elements {
+		encountered[elements[v]] = true
+	}
+
+	// Place all keys from the map into a slice.
+	result := []string{}
+	for key := range encountered {
+		result = append(result, key)
+	}
+	return result
+}
+
+func difference(a map[string]string, b map[string]bool) []string {
+	new := []string{}
+	for key1 := range a {
+		if _, ok := b[key1]; !ok {
+			new = append(new, key1)
+		}
+	}
+	return new
 }
 
 // Write writes the javascript represented by the given node to the given
 // writer.  The first error encountered is returned.
 func Write(out io.Writer, node ast.Node, options Options) (err error) {
 	defer errRecover(&err)
-	var s = &state{wr: out, options: options}
+
+	if options.Formatter == nil {
+		options.Formatter = &ES5Formatter{}
+	}
+
+	var (
+		tmpOut     = &bytes.Buffer{}
+		importsBuf = &bytes.Buffer{}
+		s          = &state{
+			wr:          tmpOut,
+			options:     options,
+			funcsCalled: map[string]string{},
+			funcsInFile: map[string]bool{},
+		}
+	)
+
 	s.scope.push()
 	s.walk(node)
+
+	if len(s.funcsCalled) > 0 {
+		for _, f := range difference(s.funcsCalled, s.funcsInFile) {
+			importsBuf.Write([]byte(s.funcsCalled[f]))
+			importsBuf.Write([]byte("\n"))
+		}
+		importsBuf.Write([]byte("\n"))
+	}
+
+	out.Write(importsBuf.Bytes())
+	out.Write(tmpOut.Bytes())
+
 	return nil
 }
 
@@ -145,7 +243,7 @@ func (s *state) walk(node ast.Node) {
 			keys  = make([]string, len(node.Items))
 			i     = 0
 		)
-		for k, _ := range node.Items {
+		for k := range node.Items {
 			keys[i] = k
 			i++
 		}
@@ -263,7 +361,9 @@ func (s *state) visitTemplate(node *ast.TemplateNode) {
 	}
 
 	s.jsln("")
-	s.jsln(node.Name, " = function(opt_data, opt_sb, opt_ijData) {")
+	callName, callStyle := s.options.Formatter.Template(node.Name)
+	s.jsln(callStyle, "(opt_data, opt_sb, opt_ijData) {")
+	s.funcsInFile[callName] = true
 	s.indentLevels++
 	if allOptionalParams {
 		s.jsln("opt_data = opt_data || {};")
@@ -296,6 +396,9 @@ func (s *state) visitPrint(node *ast.PrintNode) {
 			// no implementation, they just serve as a marker to cancel autoescape.
 		default:
 			directives = append(directives, dir)
+			if impt := s.options.Formatter.Directive(directive); impt != "" {
+				s.funcsCalled[dir.Name] = impt
+			}
 		}
 	}
 	if escape != ast.AutoescapeOff {
@@ -327,6 +430,9 @@ func (s *state) visitPrint(node *ast.PrintNode) {
 func (s *state) visitFunction(node *ast.FunctionNode) {
 	if fn, ok := Funcs[node.Name]; ok {
 		fn.Apply(s, node.Args)
+		if impt := s.options.Formatter.Function(fn); impt != "" {
+			s.funcsCalled[node.Name] = impt
+		}
 		return
 	}
 
@@ -405,7 +511,11 @@ func (s *state) visitCall(node *ast.CallNode) {
 		}
 		dataExpr += "})"
 	}
-	s.jsln(s.bufferName, " += ", node.Name, "(", dataExpr, ", opt_sb, opt_ijData);")
+	callName, importString := s.options.Formatter.Call(node.Name)
+	s.jsln(s.bufferName, " += ", callName, "(", dataExpr, ", opt_sb, opt_ijData);")
+	if importString != "" {
+		s.funcsCalled[callName] = importString
+	}
 }
 
 func (s *state) visitIf(node *ast.IfNode) {
@@ -657,7 +767,7 @@ func (s *state) writeRawText(text []byte) {
 // block renders the given node to a temporary buffer and returns the string.
 func (s *state) block(node ast.Node) string {
 	var buf bytes.Buffer
-	(&state{wr: &buf, scope: s.scope}).walk(node)
+	(&state{wr: &buf, scope: s.scope, options: s.options, funcsCalled: s.funcsCalled, funcsInFile: s.funcsInFile}).walk(node)
 	return buf.String()
 }
 

--- a/soyjs/exec_test.go
+++ b/soyjs/exec_test.go
@@ -10,7 +10,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/andreyvit/diff"
 	"github.com/robertkrimen/otto"
+	"github.com/robfig/soy"
 	"github.com/robfig/soy/ast"
 	"github.com/robfig/soy/data"
 	"github.com/robfig/soy/parse"
@@ -1042,6 +1044,60 @@ soy.$$escapeHtml = function(arg) { return arg; };
 	val, _ := otto.Get("console_output")
 	if val.String() != "Hello Rob." {
 		t.Errorf("got %q", val.String())
+	}
+}
+
+func TestES6(t *testing.T) {
+	bundle := soy.NewBundle()
+	bundle.AddTemplateString("test_formatter.soy", `
+	{namespace test}
+	{template .formatter}
+	{call say.hello /}
+	{/template}`)
+	bundle.AddTemplateString("say_hello.soy", `
+	{namespace say}
+	{template .hello}
+	Hello World!
+	{/template}`)
+	registry, err := bundle.Compile()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	expected := []string{
+		`import { say__hello } from 'say.hello.js';
+
+// This file was automatically generated from test_formatter.soy.
+// Please don't edit this file by hand.
+
+if (typeof test == 'undefined') { var test = {}; }
+
+export function test__formatter(opt_data, opt_sb, opt_ijData) {
+  var output = '';
+  output += say__hello({}, opt_sb, opt_ijData);
+  return output;
+};`,
+		`// This file was automatically generated from say_hello.soy.
+// Please don't edit this file by hand.
+
+if (typeof say == 'undefined') { var say = {}; }
+
+export function say__hello(opt_data, opt_sb, opt_ijData) {
+  var output = '';
+  output += 'Hello World!';
+  return output;
+};`,
+	}
+	for i, soyfile := range registry.SoyFiles {
+		var buf bytes.Buffer
+		err := Write(&buf, soyfile, Options{Formatter: ES6Formatter{}})
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if a, e := strings.TrimSpace(buf.String()), strings.TrimSpace(expected[i]); a != e {
+			t.Errorf("ES6 Error, did not get expected results:\n%v", diff.LineDiff(e, a))
+		}
 	}
 }
 

--- a/soyjs/exec_test.go
+++ b/soyjs/exec_test.go
@@ -1049,16 +1049,14 @@ soy.$$escapeHtml = function(arg) { return arg; };
 
 func TestES6(t *testing.T) {
 	bundle := soy.NewBundle()
-	bundle.AddTemplateString("test_formatter.soy", `
-	{namespace test}
-	{template .formatter}
+	bundle.AddTemplateString("test_formatter.soy", `{namespace test}
+{template .formatter}
 	{call say.hello /}
-	{/template}`)
-	bundle.AddTemplateString("say_hello.soy", `
-	{namespace say}
-	{template .hello}
+{/template}`)
+	bundle.AddTemplateString("say_hello.soy", `{namespace say}
+{template .hello}
 	Hello World!
-	{/template}`)
+{/template}`)
 	registry, err := bundle.Compile()
 	if err != nil {
 		t.Error(err)

--- a/soyjs/formatters.go
+++ b/soyjs/formatters.go
@@ -1,0 +1,109 @@
+package soyjs
+
+import (
+    "strings"
+)
+
+// The JSFormatter interface allows for callers to choose which
+// version of Javascript they would like soyjs to output. To
+// maintain backwards compatibility, if no JSFormatter is specified
+// in the Options, soyjs will default to the ES5Formatter implemented
+// in exec.go
+type JSFormatter interface {
+    // Template returns two values, the name of the template to save
+    // in the defined functions map, and how the function should be defined.
+	Template(name string) (string, string)
+    // Call returns two values, the name of the template to save
+    // in the called functions map, and a string that is written
+    // into the imports
+	Call(name string) (string, string)
+    // Directive takes in a PrintDirective and returns a string
+    // that is written into the imports
+	Directive(PrintDirective) string
+    // Function takes in a Func and returns a string
+    // that is written into the imports
+	Function(Func) string
+}
+
+// ES5Formatter implements the JSFormatter interface
+// and creates Javascript files following the ES5
+// Javascript format (without imports)
+type ES5Formatter struct{}
+
+// ES6Formatter implements the JSFormatter interface
+// and creates Javascript files following the ES6
+// Javascript format (with imports)
+type ES6Formatter struct{}
+
+var _ JSFormatter = (*ES6Formatter)(nil)
+var _ JSFormatter = (*ES5Formatter)(nil)
+
+// Template returns two values, the name of the template to save
+// in the defined functions map, and how the function should be defined.
+// For ES5, the function is not exported, but defined globally
+func (f ES5Formatter) Template(name string) (string, string) {
+	return name, name + " = function"
+}
+
+// Call returns two values, the name of the template to save
+// in the called functions map, and a string that is written
+// into the imports - for ES5, there are no imports
+func (f ES5Formatter) Call(name string) (string, string) {
+	return name, ""
+}
+
+// Directive takes in a PrintDirective and returns a string
+// that is written into the imports - for ES5, there
+// are no imports
+func (f ES5Formatter) Directive(dir PrintDirective) string {
+	return ""
+}
+
+// Function takes in a Func and returns a string
+// that is written into the imports - for ES5, there
+// are no imports
+func (f ES5Formatter) Function(fn Func) string {
+	return ""
+}
+
+// ES6Identifier creates an ES6 compatible function name
+// without periods. It replaces all periods, which usually
+// denominate namespaces in soy, with a double underscore.
+// For example, from the file
+//  {namespace say}
+//  {template .hello_world}
+//  Hello World
+//  {/template}
+// when ES6Identifier is called on
+//  say.hello_world
+// it will return
+//  say__hello_world
+func ES6Identifier(s string) string {
+	return strings.Replace(s, ".", "__", -1)
+}
+
+// Template returns two values, the name of the template to save
+// in the defined functions map, and how the function should be defined.
+// For ES6, the function is not defined globally, but exported
+func (f ES6Formatter) Template(name string) (string, string) {
+	return ES6Identifier(name), "export function " + ES6Identifier(name)
+}
+
+// Call returns two values, the name of the template to save
+// in the called functions map, and a string that is written
+// into the imports
+func (f ES6Formatter) Call(name string) (string, string) {
+	return ES6Identifier(name), "import { " + ES6Identifier(name) + " } from '" + name + ".js';"
+}
+
+// Directive takes in a PrintDirective and returns a string
+// that is written into the imports
+func (f ES6Formatter) Directive(dir PrintDirective) string {
+	return "import { " + ES6Identifier(dir.Name) + " } from '" + dir.Name + ".js';"
+}
+
+// Function takes in a Func and returns a string
+// that is written into the imports
+func (f ES6Formatter) Function(fn Func) string {
+	return "import { " + ES6Identifier(fn.Name) + " } from '" + fn.Name + ".js';"
+}

--- a/soyjs/funcs.go
+++ b/soyjs/funcs.go
@@ -23,25 +23,33 @@ type Func struct {
 	ValidArgLengths []int
 }
 
+var funcs = []Func{
+	{"isNonnull", funcIsNonnull, []int{1}},
+	{"length", funcLength, []int{1}},
+	{"keys", builtinFunc("getMapKeys"), []int{1}},
+	{"augmentMap", builtinFunc("augmentMap"), []int{2}},
+	{"round", funcRound, []int{1, 2}},
+	{"floor", funcFloor, []int{1}},
+	{"ceiling", funcCeiling, []int{1}},
+	{"min", funcMin, []int{2}},
+	{"max", funcMax, []int{2}},
+	{"randomInt", funcRandomInt, []int{1}},
+	{"strContains", funcStrContains, []int{2}},
+	{"hasData", funcHasData, []int{0}},
+	{"bidiGlobalDir", funcBidiGlobalDir, []int{0}},
+	{"bidiDirAttr", funcBidiDirAttr, []int{0}},
+	{"bidiStartEdge", funcBidiStartEdge, []int{0}},
+	{"bidiEndEdge", funcBidiEndEdge, []int{0}},
+}
+
 // Funcs contains the available soy functions.
 // Callers may add custom functions to this map.
-var Funcs = map[string]Func{
-	"isNonnull":     {"isNonnull", funcIsNonnull, []int{1}},
-	"length":        {"length", funcLength, []int{1}},
-	"keys":          {"keys", builtinFunc("getMapKeys"), []int{1}},
-	"augmentMap":    {"augmentMap", builtinFunc("augmentMap"), []int{2}},
-	"round":         {"round", funcRound, []int{1, 2}},
-	"floor":         {"floor", funcFloor, []int{1}},
-	"ceiling":       {"ceiling", funcCeiling, []int{1}},
-	"min":           {"min", funcMin, []int{2}},
-	"max":           {"max", funcMax, []int{2}},
-	"randomInt":     {"randomInt", funcRandomInt, []int{1}},
-	"strContains":   {"strContains", funcStrContains, []int{2}},
-	"hasData":       {"hasData", funcHasData, []int{0}},
-	"bidiGlobalDir": {"bidiGlobalDir", funcBidiGlobalDir, []int{0}},
-	"bidiDirAttr":   {"bidiDirAttr", funcBidiDirAttr, []int{0}},
-	"bidiStartEdge": {"bidiStartEdge", funcBidiStartEdge, []int{0}},
-	"bidiEndEdge":   {"bidiEndEdge", funcBidiEndEdge, []int{0}},
+var Funcs = make(map[string]Func, len(funcs))
+
+func init() {
+	for _, f := range funcs {
+		Funcs[f.Name] = f
+	}
 }
 
 // builtinFunc returns a function that writes a call to a soy.$$ builtin func.

--- a/soyjs/funcs.go
+++ b/soyjs/funcs.go
@@ -1,6 +1,8 @@
 package soyjs
 
-import "github.com/robfig/soy/ast"
+import (
+	"github.com/robfig/soy/ast"
+)
 
 // JSWriter is provided to functions to write to the generated javascript.
 type JSWriter interface {
@@ -16,6 +18,7 @@ func (s *state) Write(args ...interface{}) {
 
 // Func represents a soy function that may invoked within a template.
 type Func struct {
+	Name            string
 	Apply           func(js JSWriter, args []ast.Node)
 	ValidArgLengths []int
 }
@@ -23,22 +26,22 @@ type Func struct {
 // Funcs contains the available soy functions.
 // Callers may add custom functions to this map.
 var Funcs = map[string]Func{
-	"isNonnull":     {funcIsNonnull, []int{1}},
-	"length":        {funcLength, []int{1}},
-	"keys":          {builtinFunc("getMapKeys"), []int{1}},
-	"augmentMap":    {builtinFunc("augmentMap"), []int{2}},
-	"round":         {funcRound, []int{1, 2}},
-	"floor":         {funcFloor, []int{1}},
-	"ceiling":       {funcCeiling, []int{1}},
-	"min":           {funcMin, []int{2}},
-	"max":           {funcMax, []int{2}},
-	"randomInt":     {funcRandomInt, []int{1}},
-	"strContains":   {funcStrContains, []int{2}},
-	"hasData":       {funcHasData, []int{0}},
-	"bidiGlobalDir": {funcBidiGlobalDir, []int{0}},
-	"bidiDirAttr":   {funcBidiDirAttr, []int{0}},
-	"bidiStartEdge": {funcBidiStartEdge, []int{0}},
-	"bidiEndEdge":   {funcBidiEndEdge, []int{0}},
+	"isNonnull":     {"isNonnull", funcIsNonnull, []int{1}},
+	"length":        {"length", funcLength, []int{1}},
+	"keys":          {"keys", builtinFunc("getMapKeys"), []int{1}},
+	"augmentMap":    {"augmentMap", builtinFunc("augmentMap"), []int{2}},
+	"round":         {"round", funcRound, []int{1, 2}},
+	"floor":         {"floor", funcFloor, []int{1}},
+	"ceiling":       {"ceiling", funcCeiling, []int{1}},
+	"min":           {"min", funcMin, []int{2}},
+	"max":           {"max", funcMax, []int{2}},
+	"randomInt":     {"randomInt", funcRandomInt, []int{1}},
+	"strContains":   {"strContains", funcStrContains, []int{2}},
+	"hasData":       {"hasData", funcHasData, []int{0}},
+	"bidiGlobalDir": {"bidiGlobalDir", funcBidiGlobalDir, []int{0}},
+	"bidiDirAttr":   {"bidiDirAttr", funcBidiDirAttr, []int{0}},
+	"bidiStartEdge": {"bidiStartEdge", funcBidiStartEdge, []int{0}},
+	"bidiEndEdge":   {"bidiEndEdge", funcBidiEndEdge, []int{0}},
 }
 
 // builtinFunc returns a function that writes a call to a soy.$$ builtin func.

--- a/soyjs/generator.go
+++ b/soyjs/generator.go
@@ -8,6 +8,24 @@ import (
 	"github.com/robfig/soy/template"
 )
 
+// The JSFormatter interface allows for callers to choose which
+// version of Javascript they would like soyjs to output. To
+// maintain backwards compatibility, if no JSFormatter is specified
+// in the Options, soyjs will default to the ES5Formatter implemented
+// in exec.go
+//
+// Template returns two values, the name of the template to save
+// in the defined functions map, and how the function should be defined.
+//
+// Call returns two values, the name of the template to save
+// in the called functions map, and a string that is written
+// into the imports
+//
+// Directive takes in a PrintDirective and returns a string
+// that is written into the imports
+//
+// Function takes in a Func and returns a string
+// that is written into the imports
 type JSFormatter interface {
 	Template(name string) (string, string)
 	Call(name string) (string, string)
@@ -16,6 +34,8 @@ type JSFormatter interface {
 }
 
 // Options for js source generation.
+// When no Formatter is defined, soyjs
+// will default to ES5Formatter from exec.go
 type Options struct {
 	Messages  soymsg.Bundle
 	Formatter JSFormatter

--- a/soyjs/generator.go
+++ b/soyjs/generator.go
@@ -8,31 +8,6 @@ import (
 	"github.com/robfig/soy/template"
 )
 
-// The JSFormatter interface allows for callers to choose which
-// version of Javascript they would like soyjs to output. To
-// maintain backwards compatibility, if no JSFormatter is specified
-// in the Options, soyjs will default to the ES5Formatter implemented
-// in exec.go
-//
-// Template returns two values, the name of the template to save
-// in the defined functions map, and how the function should be defined.
-//
-// Call returns two values, the name of the template to save
-// in the called functions map, and a string that is written
-// into the imports
-//
-// Directive takes in a PrintDirective and returns a string
-// that is written into the imports
-//
-// Function takes in a Func and returns a string
-// that is written into the imports
-type JSFormatter interface {
-	Template(name string) (string, string)
-	Call(name string) (string, string)
-	Directive(PrintDirective) string
-	Function(Func) string
-}
-
 // Options for js source generation.
 // When no Formatter is defined, soyjs
 // will default to ES5Formatter from exec.go

--- a/soyjs/generator.go
+++ b/soyjs/generator.go
@@ -8,9 +8,17 @@ import (
 	"github.com/robfig/soy/template"
 )
 
+type JSFormatter interface {
+	Template(name string) (string, string)
+	Call(name string) (string, string)
+	Directive(PrintDirective) string
+	Function(Func) string
+}
+
 // Options for js source generation.
 type Options struct {
-	Messages soymsg.Bundle
+	Messages  soymsg.Bundle
+	Formatter JSFormatter
 }
 
 // Generator provides an interface to a template registry capable of generating

--- a/soyjs/generator_test.go
+++ b/soyjs/generator_test.go
@@ -21,7 +21,7 @@ soy.$$escapeHtml = function(arg) { return arg; };
 		return
 	}
 
-	Funcs["capitalize"] = Func{func(js JSWriter, args []ast.Node) {
+	Funcs["capitalize"] = Func{"capitalize", func(js JSWriter, args []ast.Node) {
 		js.Write("(", args[0], ".charAt(0).toUpperCase() + ", args[0], ".slice(1))")
 	}, []int{1}}
 	defer delete(Funcs, "capitalize")


### PR DESCRIPTION
- export functions that are declared (templates)
- import functions that are not already in the file and are called
(call, print directive, func)
- maintains ES5 compatibility
- callers can define and pass their own `JSFormatter` or use the ones provided by `soyjs`