### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/soymsg/pomsg/msgid.go
+++ b/soymsg/pomsg/msgid.go
@@ -32,7 +32,7 @@ func Msgid(n *ast.MsgNode) string {
 	return msgidn(n, true)
 }
 
-// MsgPlural returns the msgid_plural for the given message.
+// MsgidPlural returns the msgid_plural for the given message.
 func MsgidPlural(n *ast.MsgNode) string {
 	return msgidn(n, false)
 }


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?