### PR TITLE
Fix spelling of "preceding" / "preceded"

### DIFF
--- a/parse/lexer.go
+++ b/parse/lexer.go
@@ -471,7 +471,7 @@ func lexText(l *lexer) stateFn {
 				if lastCharEmitted == 0 || isSpaceEOL(lastCharEmitted) {
 					maybeEmitText(l, 3)
 					if lastChar != 0 {
-						l.start++ // ignore the preceeding space, if present.
+						l.start++ // ignore the preceding space, if present.
 					}
 					return lexLineComment(l)
 				}

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -200,7 +200,7 @@ func (t *tree) parsePrint(token item) ast.Node {
 			var id = t.expect(itemIdent, "print directive")
 			var args []ast.Node
 			for {
-				// each argument is preceeded by a colon (first arg) or comma (subsequent)
+				// each argument is preceded by a colon (first arg) or comma (subsequent)
 				switch next := t.next(); next.typ {
 				case itemColon, itemComma:
 					args = append(args, t.parseExpr(0))

--- a/template/template.go
+++ b/template/template.go
@@ -3,7 +3,7 @@ package template
 import "github.com/robfig/soy/ast"
 
 // Template is a Soy template's parse tree, including the relevant context
-// (preceeding soydoc and namespace).
+// (preceding soydoc and namespace).
 type Template struct {
 	Doc       *ast.SoyDocNode    // this template's SoyDoc
 	Node      *ast.TemplateNode  // this template's node


### PR DESCRIPTION
All instances of misspellings appear in comments, so there are no functional or
API changes as a result of the fix.

This was pointed out in the Go Report Card:
https://goreportcard.com/report/github.com/robfig/soy#misspell