### PR TITLE
Uppercase Soy when used as a proper noun.

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -10,10 +10,10 @@ import (
 	"github.com/robfig/soy/data"
 )
 
-// Node represents any singular piece of a soy template.  For example, a
+// Node represents any singular piece of a Soy template.  For example, a
 // sequence of raw text or a print tag.
 type Node interface {
-	String() string // String returns the soy source representation of this node.
+	String() string // String returns the Soy source representation of this node.
 	Position() Pos  // byte position of start of node in full original input string
 }
 
@@ -34,7 +34,7 @@ func (p Pos) Position() Pos {
 	return p
 }
 
-// SoyFileNode represents a soy file.
+// SoyFileNode represents a Soy file.
 type SoyFileNode struct {
 	Name string
 	Text string
@@ -84,7 +84,7 @@ func (t *RawTextNode) String() string {
 	return string(t.Text)
 }
 
-// NamespaceNode registers the namespace of the soy file.
+// NamespaceNode registers the namespace of the Soy file.
 type NamespaceNode struct {
 	Pos
 	Name       string
@@ -145,7 +145,7 @@ func (n *SoyDocNode) Children() []Node {
 	return nodes
 }
 
-// SoyDocParam represents a parameter to a soy template.
+// SoyDocParam represents a parameter to a Soy template.
 // e.g.
 //  /**
 //   * Says hello to the person

--- a/bundle.go
+++ b/bundle.go
@@ -23,8 +23,8 @@ var Logger = log.New(os.Stderr, "[soy] ", 0)
 
 type soyFile struct{ name, content string }
 
-// Bundle is a collection of soy content (templates and globals).  It acts as
-// input for the soy compiler.
+// Bundle is a collection of Soy content (templates and globals).  It acts as
+// input for the Soy compiler.
 type Bundle struct {
 	files                 []soyFile
 	globals               data.Map
@@ -39,7 +39,7 @@ func NewBundle() *Bundle {
 	return &Bundle{globals: make(data.Map)}
 }
 
-// WatchFiles tells soy to watch any template files added to this bundle,
+// WatchFiles tells Soy to watch any template files added to this bundle,
 // re-compile as necessary, and propagate the updates to your tofu.  It should
 // be called once, before adding any files.
 func (b *Bundle) WatchFiles(watch bool) *Bundle {
@@ -71,7 +71,7 @@ func (b *Bundle) AddTemplateDir(root string) *Bundle {
 	return b
 }
 
-// AddTemplateFile adds the given soy template file text to this bundle.
+// AddTemplateFile adds the given Soy template file text to this bundle.
 // If WatchFiles is on, it will be subsequently watched for updates.
 func (b *Bundle) AddTemplateFile(filename string) *Bundle {
 	content, err := ioutil.ReadFile(filename)
@@ -127,20 +127,20 @@ func (b *Bundle) SetRecompilationCallback(c func(*template.Registry)) *Bundle {
 }
 
 // AddParsePass adds a function to the bundle that will be called
-// after the soy is parsed
+// after the Soy is parsed.
 func (b *Bundle) AddParsePass(f func(template.Registry) error) *Bundle {
 	b.parsepasses = append(b.parsepasses, f)
 	return b
 }
 
-// Compile parses all of the soy files in this bundle, verifies a number of
+// Compile parses all of the Soy files in this bundle, verifies a number of
 // rules about data references, and returns the completed template registry.
 func (b *Bundle) Compile() (*template.Registry, error) {
 	if b.err != nil {
 		return nil, b.err
 	}
 
-	// Compile all the soy (globals are already parsed)
+	// Compile all the Soy (globals are already parsed).
 	var registry = template.Registry{}
 	for _, soyfile := range b.files {
 		var tree, err = parse.SoyFile(soyfile.name, soyfile.content)
@@ -193,7 +193,7 @@ func (b *Bundle) recompiler(reg *template.Registry) {
 				}
 			}
 
-			// Recompile all the soy.
+			// Recompile all the Soy.
 			var bundle = NewBundle().
 				AddGlobalsMap(b.globals)
 			for _, soyfile := range b.files {

--- a/data/convert.go
+++ b/data/convert.go
@@ -10,13 +10,13 @@ import (
 
 var timeType = reflect.TypeOf(time.Time{})
 
-// New converts the given data into a soy data value, using
+// New converts the given data into a Soy data value, using
 // DefaultStructOptions for structs.
 func New(value interface{}) Value {
 	return NewWith(DefaultStructOptions, value)
 }
 
-// NewWith converts the given data value soy data value, using the provided
+// NewWith converts the given data value Soy data value, using the provided
 // StructOptions for any structs encountered.
 func NewWith(convert StructOptions, value interface{}) Value {
 	// quick return if we're passed an existing data.Value

--- a/doc.go
+++ b/doc.go
@@ -79,7 +79,7 @@ template data to the callee template.
 This example is from
 https://developers.google.com/closure/templates/docs/helloworld_java.
 
-Many more examples of soy language features/commands may be seen here:
+Many more examples of Soy language features/commands may be seen here:
 https://github.com/robfig/soy/blob/master/testdata/features.soy
 
 Usage example
@@ -101,16 +101,16 @@ your pages.  For example:
   app/views/feed/
   ...
 
-This code snippet will parse a file of globals, all soy templates within
+This code snippet will parse a file of globals, all Soy templates within
 app/views, and provide back a Tofu intance that can be used to render any
-declared template.  Additionally, if "mode == dev", it will watch the soy files
+declared template.  Additionally, if "mode == dev", it will watch the Soy files
 for changes and update your compiled templates in the background (or log compile
 errors to soy.Logger).  Error checking is omitted.
 
 On startup:
 
   tofu, _ := soy.NewBundle().
-      WatchFiles(true).                     // watch soy files, reload on changes
+      WatchFiles(true).                     // watch Soy files, reload on changes
       AddGlobalsFile("views/globals.txt").  // parse a file of globals
       AddTemplateDir("views").              // load *.soy in all sub-directories
       CompileToTofu()

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -1,4 +1,4 @@
-// Package parse converts a soy template into its in-memory representation (AST)
+// Package parse converts a Soy template into its in-memory representation (AST)
 package parse
 
 import (
@@ -15,7 +15,7 @@ import (
 	"github.com/robfig/soy/errortypes"
 )
 
-// tree is the parsed representation of a single soy file.
+// tree is the parsed representation of a single Soy file.
 type tree struct {
 	name      string            // name provided for the input
 	root      *ast.ListNode     // top-level root of the tree
@@ -29,7 +29,7 @@ type tree struct {
 }
 
 // SoyFile parses the input into a SoyFileNode (the AST).
-// The result may be used as input to a soy backend to generate HTML or JS.
+// The result may be used as input to a Soy backend to generate HTML or JS.
 func SoyFile(name, text string) (node *ast.SoyFileNode, err error) {
 	var t = &tree{
 		name:    name,
@@ -761,7 +761,7 @@ func (t *tree) parseTemplate(token item) ast.Node {
 
 // Expressions ----------
 
-// Expr returns the parsed representation of the given soy expression.
+// Expr returns the parsed representation of the given Soy expression.
 // An expression is basically anything that you can put inside a print tag.
 // For example, string, list or map literals, arithmetic, boolean operations, etc.
 func Expr(str string) (node ast.Node, err error) {

--- a/parse/quote.go
+++ b/parse/quote.go
@@ -39,7 +39,7 @@ func quoteString(s string) string {
 	return string(append(q, '\''))
 }
 
-// unquoteString takes a quoted soy string (including the surrounding quotes)
+// unquoteString takes a quoted Soy string (including the surrounding quotes)
 // and returns the unquoted string, along with any error encountered.
 func unquoteString(s string) (string, error) {
 	n := len(s)

--- a/soyhtml/funcs.go
+++ b/soyhtml/funcs.go
@@ -29,13 +29,13 @@ func funcIsLast(s *state, key string) data.Value {
 		s.context.lookup(key+"__index").(data.Int) == s.context.lookup(key+"__lastIndex").(data.Int))
 }
 
-// Func represents a soy function that may be invoked within a soy template.
+// Func represents a Soy function that may be invoked within a Soy template.
 type Func struct {
 	Apply           func([]data.Value) data.Value
 	ValidArgLengths []int
 }
 
-// Funcs contains the builtin soy functions.
+// Funcs contains the builtin Soy functions.
 // Callers may add their own functions to this map as well.
 var Funcs = map[string]Func{
 	"isNonnull":   {funcIsNonnull, []int{1}},

--- a/soyhtml/tofu.go
+++ b/soyhtml/tofu.go
@@ -20,7 +20,7 @@ func NewTofu(registry *template.Registry) *Tofu {
 	return &Tofu{registry}
 }
 
-// Render is a convenience function that executes the soy template of the given
+// Render is a convenience function that executes the Soy template of the given
 // name, using the given object (converted to data.Map) as context, and writes
 // the results to the given Writer.
 //
@@ -40,7 +40,7 @@ func (tofu Tofu) Render(wr io.Writer, name string, obj interface{}) error {
 	return tofu.NewRenderer(name).Execute(wr, m)
 }
 
-// NewRenderer returns a new instance of a soy html renderer, given the
+// NewRenderer returns a new instance of a Soy html renderer, given the
 // fully-qualified name of the template to render.
 func (tofu *Tofu) NewRenderer(name string) *Renderer {
 	return &Renderer{

--- a/soyjs/exec.go
+++ b/soyjs/exec.go
@@ -358,7 +358,7 @@ func (s *state) visitPrint(node *ast.PrintNode) {
 			s.js(",")
 			s.walk(arg)
 		}
-		// soy specifies truncate adds ellipsis by default, so we have to pass
+		// Soy specifies truncate adds ellipsis by default, so we have to pass
 		// doAddEllipsis = true to soy.$$truncate
 		if dir.Name == "truncate" && len(dir.Args) == 1 {
 			s.js(",true")

--- a/soyjs/exec_test.go
+++ b/soyjs/exec_test.go
@@ -94,7 +94,7 @@ func TestExpressions(t *testing.T) {
 		exprtest("arithmetic2", "{2.0-1.5}", "0.5"),
 		exprtest("bools", "{not false and (2 > 5.0 or (null ?: true))}", "true"),
 		exprtest("bools2", "{2*(1.5+1) < 3 ? 'nope' : (2 >= 2) == (5.5<6) != true }", "false"),
-		// DIFFERENCE: official soy returns true but prints nothing.  (weird!)
+		// DIFFERENCE: official Soy returns true but prints nothing.  (weird!)
 		// ({true} prints true. {[:]} is truthy but prints nothing.)
 		// exprtest("bools3", "{null or 0.0 or ([:] and [])}", "true"), // map/list is truthy
 		exprtest("bools4", "{'a' == 'a'}", "true"),

--- a/soyjs/funcs.go
+++ b/soyjs/funcs.go
@@ -16,7 +16,7 @@ func (s *state) Write(args ...interface{}) {
 	s.js(args...)
 }
 
-// Func represents a soy function that may invoked within a template.
+// Func represents a Soy function that may invoked within a template.
 type Func struct {
 	Name            string
 	Apply           func(js JSWriter, args []ast.Node)
@@ -42,7 +42,7 @@ var funcs = []Func{
 	{"bidiEndEdge", funcBidiEndEdge, []int{0}},
 }
 
-// Funcs contains the available soy functions.
+// Funcs contains the available Soy functions.
 // Callers may add custom functions to this map.
 var Funcs = make(map[string]Func, len(funcs))
 

--- a/soyjs/generator.go
+++ b/soyjs/generator.go
@@ -31,7 +31,7 @@ func NewGenerator(registry *template.Registry) *Generator {
 
 var ErrNotFound = errors.New("file not found")
 
-// WriteFile generates javascript corresponding to the soy file of the given name.
+// WriteFile generates javascript corresponding to the Soy file of the given name.
 func (gen *Generator) WriteFile(out io.Writer, filename string) error {
 	for _, soyfile := range gen.registry.SoyFiles {
 		if soyfile.Name == filename {

--- a/soyjs/scope.go
+++ b/soyjs/scope.go
@@ -2,7 +2,7 @@ package soyjs
 
 import "strconv"
 
-// scope provides a lookup from soy variable name to the JS name.
+// scope provides a lookup from Soy variable name to the JS name.
 // it is pushed and popped upon entering and leaving loop scopes.
 type scope struct {
 	stack []map[string]string

--- a/template/registry.go
+++ b/template/registry.go
@@ -1,4 +1,4 @@
-// Package template provides convenient access to groups of parsed soy files.
+// Package template provides convenient access to groups of parsed Soy files.
 package template
 
 import (
@@ -19,7 +19,7 @@ type Registry struct {
 	fileByTemplateName   map[string]string
 }
 
-// Add the given soy file node (and all contained templates) to this registry.
+// Add the given Soy file node (and all contained templates) to this registry.
 func (r *Registry) Add(soyfile *ast.SoyFileNode) error {
 	if r.sourceByTemplateName == nil {
 		r.sourceByTemplateName = make(map[string]string)


### PR DESCRIPTION
This primarily affects when "Soy" is used in comments, so this commit has no
functional changes and does not change any APIs, public or private.