### PR TITLE
Clean up Go code with `gofmt -s`

### DIFF
--- a/parse/lexer.go
+++ b/parse/lexer.go
@@ -322,7 +322,7 @@ func (l *lexer) nextItem() item {
 
 // drain drains the output so the lexing goroutine will exit.
 func (l *lexer) drain() {
-	for _ = range l.items {
+	for range l.items {
 	}
 }
 

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -240,18 +240,16 @@ var parseTests = []parseTest{
   Blah {$moo}
 {/if}`, tFile(
 		&ast.IfNode{0, []*ast.IfCondNode{
-			&ast.IfCondNode{0, &ast.DataRefNode{0, "zoo", nil}, tList(&ast.PrintNode{0, &ast.DataRefNode{0, "zoo", nil}, nil})},
+			{0, &ast.DataRefNode{0, "zoo", nil}, tList(&ast.PrintNode{0, &ast.DataRefNode{0, "zoo", nil}, nil})},
 		}},
 		&ast.IfNode{0, []*ast.IfCondNode{
-			&ast.IfCondNode{0, &ast.DataRefNode{0, "boo", nil}, tList(newText(0, "Blah"))},
-			&ast.IfCondNode{0,
+			{0, &ast.DataRefNode{0, "boo", nil}, tList(newText(0, "Blah"))},
+			{0,
 				&ast.GtNode{bin(
 					&ast.DataRefNode{0, "foo", []ast.Node{&ast.DataRefKeyNode{0, false, "goo"}}},
 					&ast.IntNode{0, 2})},
 				tList(&ast.PrintNode{0, &ast.DataRefNode{0, "boo", nil}, nil})},
-			&ast.IfCondNode{0,
-				nil,
-				tList(newText(0, "Blah "), &ast.PrintNode{0, &ast.DataRefNode{0, "moo", nil}, nil})},
+			{0, nil, tList(newText(0, "Blah "), &ast.PrintNode{0, &ast.DataRefNode{0, "moo", nil}, nil})},
 		}},
 	)},
 
@@ -265,14 +263,14 @@ var parseTests = []parseTest{
     Bloh
 {/switch}`, tFile(
 		&ast.SwitchNode{0, &ast.DataRefNode{0, "boo", nil}, []*ast.SwitchCaseNode{
-			&ast.SwitchCaseNode{0, []ast.Node{&ast.IntNode{0, 0}}, tList(newText(0, "Blah"))},
-			&ast.SwitchCaseNode{0, []ast.Node{&ast.DataRefNode{0, "foo", []ast.Node{&ast.DataRefKeyNode{0, false, "goo"}}}},
+			{0, []ast.Node{&ast.IntNode{0, 0}}, tList(newText(0, "Blah"))},
+			{0, []ast.Node{&ast.DataRefNode{0, "foo", []ast.Node{&ast.DataRefKeyNode{0, false, "goo"}}}},
 				tList(newText(0, "Bleh"))},
-			&ast.SwitchCaseNode{0, []ast.Node{
+			{0, []ast.Node{
 				&ast.IntNode{0, -1},
 				&ast.AddNode{bin(&ast.IntNode{0, 1}, &ast.IntNode{0, 1})},
 				&ast.DataRefNode{0, "moo", nil}}, tList(newText(0, "Bluh"))},
-			&ast.SwitchCaseNode{0, nil, tList(newText(0, "Bloh"))},
+			{0, nil, tList(newText(0, "Bloh"))},
 		}},
 	)},
 
@@ -297,7 +295,7 @@ var parseTests = []parseTest{
 				&ast.PrintNode{0, &ast.DataRefNode{0, "boo", []ast.Node{&ast.DataRefKeyNode{0, false, "name"}}}, nil},
 				newText(0, "!"),
 				&ast.IfNode{0,
-					[]*ast.IfCondNode{&ast.IfCondNode{0,
+					[]*ast.IfCondNode{{0,
 						&ast.NotNode{0, &ast.FunctionNode{0, "isLast", []ast.Node{&ast.DataRefNode{0, "boo", nil}}}},
 						tList(newText(0, "\n"))}}}),
 			tList(

--- a/soyhtml/funcs.go
+++ b/soyhtml/funcs.go
@@ -63,7 +63,7 @@ func funcLength(v []data.Value) data.Value {
 
 func funcKeys(v []data.Value) data.Value {
 	var keys data.List
-	for k, _ := range v[0].(data.Map) {
+	for k := range v[0].(data.Map) {
 		keys = append(keys, data.String(k))
 	}
 	return keys

--- a/soyhtml/scope.go
+++ b/soyhtml/scope.go
@@ -48,7 +48,7 @@ func (s scope) alldata() scope {
 	for i := range s {
 		var ri = len(s) - i - 1
 		if s[ri].entered {
-			return s[:ri+1 : ri+1]
+			return s[: ri+1 : ri+1]
 		}
 	}
 	panic("impossible")

--- a/soyjs/exec.go
+++ b/soyjs/exec.go
@@ -709,11 +709,11 @@ func (s *state) writeRawText(text []byte) {
 func (s *state) block(node ast.Node) string {
 	var buf bytes.Buffer
 	(&state{
-	    wr: &buf,
-	    scope: s.scope,
-	    options: s.options,
-	    funcsCalled: s.funcsCalled,
-	    funcsInFile: s.funcsInFile,
+		wr:          &buf,
+		scope:       s.scope,
+		options:     s.options,
+		funcsCalled: s.funcsCalled,
+		funcsInFile: s.funcsInFile,
 	}).walk(node)
 	return buf.String()
 }

--- a/soyjs/formatters.go
+++ b/soyjs/formatters.go
@@ -1,7 +1,7 @@
 package soyjs
 
 import (
-    "strings"
+	"strings"
 )
 
 // The JSFormatter interface allows for callers to choose which
@@ -10,18 +10,18 @@ import (
 // in the Options, soyjs will default to the ES5Formatter implemented
 // in exec.go
 type JSFormatter interface {
-    // Template returns two values, the name of the template to save
-    // in the defined functions map, and how the function should be defined.
+	// Template returns two values, the name of the template to save
+	// in the defined functions map, and how the function should be defined.
 	Template(name string) (string, string)
-    // Call returns two values, the name of the template to save
-    // in the called functions map, and a string that is written
-    // into the imports
+	// Call returns two values, the name of the template to save
+	// in the called functions map, and a string that is written
+	// into the imports
 	Call(name string) (string, string)
-    // Directive takes in a PrintDirective and returns a string
-    // that is written into the imports
+	// Directive takes in a PrintDirective and returns a string
+	// that is written into the imports
 	Directive(PrintDirective) string
-    // Function takes in a Func and returns a string
-    // that is written into the imports
+	// Function takes in a Func and returns a string
+	// that is written into the imports
 	Function(Func) string
 }
 

--- a/soymsg/pomsg/pomsg_test.go
+++ b/soymsg/pomsg/pomsg_test.go
@@ -117,15 +117,15 @@ func TestNewMessage(t *testing.T) {
 					soymsg.PluralPart{
 						VarName: "EGGS_1",
 						Cases: []soymsg.PluralCase{
-							soymsg.PluralCase{
+							{
 								Spec:  soymsg.PluralSpec{Type: soymsg.PluralSpecOther, ExplicitValue: -1},
 								Parts: []soymsg.Part{soymsg.RawTextPart{Text: "zYou zhave zone zegg"}},
 							},
-							soymsg.PluralCase{
+							{
 								Spec:  soymsg.PluralSpec{Type: soymsg.PluralSpecOther, ExplicitValue: -1},
 								Parts: []soymsg.Part{soymsg.RawTextPart{Text: "zYou zhave z{$EGGS_2} zeggs"}},
 							},
-							soymsg.PluralCase{
+							{
 								Spec:  soymsg.PluralSpec{Type: soymsg.PluralSpecOther, ExplicitValue: -1},
 								Parts: []soymsg.Part{soymsg.RawTextPart{Text: "zYou zhave ztwo zeggs"}},
 							},


### PR DESCRIPTION
Change generated via:

```
$ gofmt -s -w `find . -name \*.go`
```

No functional changes.

This was noted in the Go Report Card:
https://goreportcard.com/report/github.com/robfig/soy#gofmt