### PR TITLE
Remove ineffective assignment in parse/rawtext.go

### DIFF
--- a/parse/rawtext.go
+++ b/parse/rawtext.go
@@ -81,7 +81,6 @@ func rawtext(s string, trimBefore, trimAfter bool) []byte {
 				// ignore the space
 			}
 			spaces = 0
-			seenNewline = false
 		}
 
 		// begin to trim


### PR DESCRIPTION
This was found via Go Report Card:
https://goreportcard.com/report/github.com/robfig/soy#ineffassign
> Line 84: warning: ineffectual assignment to seenNewline (ineffassign)

According to @robfig in
https://github.com/robfig/soy/issues/78#issuecomment-649787848, this line can be
removed.

All tests pass with this change.

Closes #78