### PR TITLE
Avoid panic on unknown string escape sequence

### DIFF
--- a/parse/quote.go
+++ b/parse/quote.go
@@ -76,7 +76,7 @@ func unquoteString(s string) (string, error) {
 			} else {
 				replacement, ok := unescapes[r]
 				if !ok {
-					return "", errors.New("unrecognized escape code: \\" + s[i:i+1])
+					return "", errors.New("unrecognized escape code: \\" + s[i-1:i])
 				}
 				r = rune(replacement)
 			}

--- a/parse/quote_test.go
+++ b/parse/quote_test.go
@@ -41,3 +41,17 @@ func TestUnquote(t *testing.T) {
 		}
 	}
 }
+
+func TestUnquoteUnrecognized(t *testing.T) {
+	var tests = []string{
+		`'\0'`,
+		`'\a'`,
+		`'\z'`,
+	}
+	for _, tc := range tests {
+		_, err := unquoteString(tc)
+		if err == nil {
+			t.Errorf("expected unrecognized escape sequence %s to fail", tc)
+		}
+	}
+}


### PR DESCRIPTION
There's an off by one error when reporting unknown escape sequences in `parse/quote.go` that causes a panic, this should fix that.